### PR TITLE
config: update maven settings.xml to not use google mirror, 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,20 +4,29 @@ addons:
   apt:
     packages:
       - ant
+      - xmlstarlet
 
 jdk:
   - openjdk8
 
-script: >
-  cd ant-project && ant checkstyle
-  && cd ../gradle-project && ./gradlew clean check --debug --stacktrace
-  && rm -rf ~/.m2/repository/com/github/sevntu-checkstyle/sevntu-checks
-  && cd ../maven-project
-  && mvn checkstyle:checkstyle -Pgithub-maven-repo
-# activate after 8.28 release
-#&& mvn -f pom-google-custom-suppression.xml clean checkstyle:checkstyle -Pgithub-maven-repo
-#&& grep "error" target/checkstyle-result.xml
-#&& mvn -f pom-google.xml clean checkstyle:checkstyle -Pgithub-maven-repo
+script:
+  - cd ant-project && ant checkstyle
+  - cd ../gradle-project && ./gradlew clean check --debug --stacktrace
+  - rm -rf ~/.m2/repository/com/github/sevntu-checkstyle/sevntu-checks
+  - cd ../maven-project
+  - |
+    MVN_SETTINGS=${TRAVIS_HOME}/.m2/settings.xml
+    if [[ -f ${MVN_SETTINGS} ]]; then
+      if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
+        sed -i'' -e "/<mirrors>/,/<\/mirrors>/ d" $MVN_SETTINGS
+      else
+        xmlstarlet ed --inplace -d "//mirrors" $MVN_SETTINGS
+      fi
+    fi
+  - mvn checkstyle:checkstyle -Pgithub-maven-repo
+  - mvn -f pom-google-custom-suppression.xml clean checkstyle:checkstyle -Pgithub-maven-repo
+  - grep "error" target/checkstyle-result.xml
+  - mvn -f pom-google.xml clean checkstyle:checkstyle -Pgithub-maven-repo
 
 sudo: false
 


### PR DESCRIPTION
and activate commands of github-maven-repo profile

problems is at https://travis-ci.org/github/sevntu-checkstyle/checkstyle-samples/builds/679698363#L5869
```
[ERROR] Failed to execute goal org.apache.maven.plugins:
maven-checkstyle-plugin:3.1.1:checkstyle (default-cli) on project maven-project: 
Execution default-cli of goal org.apache.maven.plugins:
maven-checkstyle-plugin:3.1.1:checkstyle failed: Plugin 
org.apache.maven.plugins:maven-checkstyle-plugin:3.1.1 
or one of its dependencies could not be resolved: Could not find
 artifact com.puppycrawl.tools:checkstyle:jar:8.32 in sevntu-maven 
(http://sevntu-checkstyle.github.io/sevntu.checkstyle/maven2) -> [Help 1]
```