### PR TITLE
config: bump jdk to 11 as main library migrated to jdk11 at version checkstyle 10.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
   -
 
 jdk:
-  - openjdk8
+  - openjdk11
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
https://app.travis-ci.com/github/sevntu-checkstyle/checkstyle-samples/builds/249610075