### PR TITLE
Issue #35: satelite projects should use latest checkstyle as soon at is appears in maven repo

### DIFF
--- a/.ci/bump-cs-version-in-ant-project.sh
+++ b/.ci/bump-cs-version-in-ant-project.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+if [[ -z $1 ]]; then
+  echo "ERROR: version is not set"
+  echo "Usage: bump-cs-version-in-ant-project.sh <version>"
+  exit 1
+fi
+
+FILE=ant-project/ivy.xml
+VERSION=$1
+
+xmlstarlet edit --omit-decl -P --pf --inplace -u \
+  '//dependencies/dependency[@name="checkstyle"]/@rev' \
+  -v "$VERSION" $FILE
+echo "Version updated to $VERSION at $FILE"


### PR DESCRIPTION
Partially Fixes https://github.com/sevntu-checkstyle/checkstyle-samples/issues/35

Testing:
```
rahul@rk7:~/Desktop/opensource/checkstyle-samples$ ./.ci/update-project-version.sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3785  100  3785    0     0   1958      0  0:00:01  0:00:01 --:--:--  1960
LATEST_VERSION=10.3.2
CURRENT_VERSION=10.3
Checking Version for: ant-project/ivy.xml
Version updated to 10.3.2
rahul@rk7:~/Desktop/opensource/checkstyle-samples$ 
```
