### PR TITLE
Issue #35: satelite projects should use latest checkstyle as soon at is appears in maven repo

### DIFF
--- a/.ci/bump-cs-version-in-maven-project.sh
+++ b/.ci/bump-cs-version-in-maven-project.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+if [[ -z $1 ]]; then
+  echo "ERROR: version is not set"
+  echo "Usage: bump-cs-version-in-maven-project.sh <version>"
+  exit 1
+fi
+
+VERSION=$1
+
+cd maven-project
+mvn versions:set-property -Dproperty=checkstyle.version -DnewVersion="$VERSION"
+rm pom.xml.versionsBackup
+
+echo "Version updated to $VERSION at maven-project/pom.xml"


### PR DESCRIPTION
Partially Fixes #35 

Testing:
```
rahul@rk7:~/Desktop/opensource/checkstyle-samples$ ./.ci/update-pom-version.sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3785  100  3785    0     0   2595      0  0:00:01  0:00:01 --:--:--  2596
LATEST_VERSION=10.3.2
MVN_CURRENT_VERSION=0.0.1-SNAPSHOT
Checking Version for: maven-project/pom.xml
[INFO] Error stacktraces are turned on.
[INFO] Scanning for projects...
[INFO] 
[INFO] -------------< com.github.sevntu-checkstyle:maven-project >-------------
[INFO] Building maven-project 0.0.1-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- versions-maven-plugin:2.11.0:set (default-cli) @ maven-project ---
[INFO] Searching for local aggregator root...
[INFO] Local aggregation root: /home/rahul/Desktop/opensource/checkstyle-samples/maven-project
[INFO] Processing change of com.github.sevntu-checkstyle:maven-project:0.0.1-SNAPSHOT -> 10.3.2-SNAPSHOT
[INFO] Processing com.github.sevntu-checkstyle:maven-project
[INFO]     Updating project com.github.sevntu-checkstyle:maven-project
[INFO]         from version 0.0.1-SNAPSHOT to 10.3.2-SNAPSHOT
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.328 s
[INFO] Finished at: 2022-08-19T16:21:01+05:30
[INFO] ------------------------------------------------------------------------
Version updated to 10.3.2-SNAPSHOT
rahul@rk7:~/Desktop/opensource/checkstyle-samples$ 
```
