### PR TITLE
Issue #34: reinstate ivy and not download test dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,12 +33,11 @@ matrix:
   fast_finish: true
 
 script:
-  # until https://github.com/sevntu-checkstyle/checkstyle-samples/issues/34
-  # - cd ant-project && ant checkstyle
+  - cd ant-project && ant checkstyle
   # until https://github.com/gradle/gradle/issues/19295
   # - cd ../gradle-project && ./gradlew clean check --debug --stacktrace
   # - rm -rf ~/.m2/repository/com/github/sevntu-checkstyle/sevntu-checks
-  # cd ../
+  - cd ../
   - cd maven-project
   - |
     MVN_SETTINGS=${TRAVIS_HOME}/.m2/settings.xml

--- a/ant-project/ivy.xml
+++ b/ant-project/ivy.xml
@@ -1,7 +1,13 @@
 <ivy-module version="2.0">
     <info organisation="com.github.sevntu-checkstyle" module="sample"/>
+
     <dependencies>
         <dependency org="com.puppycrawl.tools" name="checkstyle" rev="10.3.4"/>
         <dependency org="com.github.sevntu-checkstyle" name="sevntu-checks" rev="1.42.0"/>
+
+        <exclude org="org.jacoco"/>
+        <exclude org="net.bytebuddy"/>
+        <exclude org="org.slf4j"/>
+        <exclude org="commons-codec"/>
     </dependencies>
 </ivy-module>


### PR DESCRIPTION
Issue #34

Fix was found at https://stackoverflow.com/questions/5640094/keep-ivy-from-including-test-dependencies