### PR TITLE
minor: convert taskdef to use classname instead of checkstyle-ant-task.properties

### DIFF
--- a/ant-project/build.xml
+++ b/ant-project/build.xml
@@ -35,16 +35,18 @@
 
     <target name="init-checkstyle" depends="resolve">
 
-        <path id="checkstyle.lib.path">
+        <!-- checkstyle itself all dependecies and Sevntu custom checks
+             are retrieved by Ivy (see ivy.xml) into lib folder
+             and will be accessible to checkstyle-->
+        <path id="execution.lib.path">
             <fileset dir="lib" includes="*.jar"/>
         </path>
 
-        <!-- Sevntu custom checks are retrieved by Ivy into lib folder
-             and will be accessible to checkstyle-->
-
-        <taskdef resource="com/puppycrawl/tools/checkstyle/ant/checkstyle-ant-task.properties"
-                 classpathref="checkstyle.lib.path"/>
-
+        <!-- loading ant task -->
+        <taskdef name="checkstyle"
+             classname="com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask"
+             classpathref="execution.lib.path"
+             />
     </target>
 
     <!-- ##########################################################################


### PR DESCRIPTION
simplification that I found during testing of https://github.com/sevntu-checkstyle/checkstyle-samples/pull/58

reference to https://github.com/checkstyle/checkstyle/blob/master/src/main/resources/com/puppycrawl/tools/checkstyle/ant/checkstyle-ant-task.properties is very weird and unfliendly

I renamed checkstyle.lib.path to execution.lib.path to make it clear that is just all jars to execute ANT tasks, it is not checkstyle specific  classpath to avoid confusion as we had in https://github.com/checkstyle/checkstyle/pull/12392#issuecomment-1366372814

idea is taken from
https://github.com/checkstyle/checkstyle/blob/45bd845a60695e8c394875819907a51371f39d21/config/ant-phase-verify.xml#L16